### PR TITLE
Add fish completion scripts

### DIFF
--- a/pog/completion.nix
+++ b/pog/completion.nix
@@ -58,8 +58,8 @@ in
           -l "${flag.name}" \
           -s "${flag.short}" \
           -d "${flag.description}" \
-          ${if flag.required then "-r" else ""} \
-          ${if flag.hasCompletion then ''-fa "(${flag.completion})"'' else "-F"}
+          ${if flag.hasCompletion then ''-fa "(${flag.completion})"'' else "-F"} \
+          ${if flag.required then "-r" else ""}
       '';
     in
     pkgs.writeScript "completion.fish"

--- a/pog/completion.nix
+++ b/pog/completion.nix
@@ -1,0 +1,75 @@
+{ name, argumentCompletion, shortDefaultFlags, parsedFlags, pkgs, ... }:
+let
+  inherit (builtins) concatStringsSep filter map;
+in
+{
+  bash =
+    let
+      argCompletion =
+        if argumentCompletion == "files" then ''
+          compopt -o default
+          COMPREPLY=()
+        '' else ''
+          completions=$(${argumentCompletion} "$current")
+          # shellcheck disable=SC2207
+          COMPREPLY=( $(compgen -W "$completions" -- "$current") )
+        '';
+    in
+    pkgs.writeScript "completion.sh"
+      # bash
+      ''
+        #! ${pkgs.bash}/bin/bash
+        # shellcheck disable=SC2317
+        _${name}()
+        {
+          local current previous completions
+          compopt +o default
+
+          flags(){
+            echo "\
+              ${if shortDefaultFlags then "-h -v " else ""}${concatStringsSep " " (map (x: "-${x.short}") (filter (x: x.short != "") parsedFlags))} \
+              --help --verbose --no-color ${concatStringsSep " " (map (x: "--${x.name}") parsedFlags)}"
+          }
+
+          COMPREPLY=()
+          current="''${COMP_WORDS[COMP_CWORD]}"
+          previous="''${COMP_WORDS[COMP_CWORD-1]}"
+
+          if [[ $current = -* ]]; then
+            completions=$(flags)
+            # shellcheck disable=SC2207
+            COMPREPLY=( $(compgen -W "$completions" -- "$current") )
+          ${concatStringsSep "\n" (map (x: x.completionBlock) parsedFlags)}
+          elif [[ $COMP_CWORD = 1 ]] || [[ $previous = -* && $COMP_CWORD = 2 ]]; then
+            ${argCompletion}
+          else
+            compopt -o default
+            COMPREPLY=()
+          fi
+          return 0
+        }
+        complete -F _${name} ${name}
+      '';
+
+  fish =
+    let
+      completeFlag = flag: ''
+        complete -c ${name} \
+          -l "${flag.name}" \
+          -s "${flag.short}" \
+          -d "${flag.description}" \
+          ${if flag.required then "-r" else ""} \
+          ${if flag.hasCompletion then ''-fa "(${flag.completion})"'' else "-F"}
+      '';
+    in
+    pkgs.writeScript "completion.fish"
+      # fish
+      ''
+        #! ${pkgs.fish}/bin/fish
+        # Plain argument completion
+        complete -c ${name} ${if argumentCompletion == "files" then "-F" else "-fa (${argumentCompletion})"}
+
+        # Flags
+        ${concatStringsSep "\n" (map completeFlag parsedFlags)}
+      '';
+}


### PR DESCRIPTION
- [x] Move completion scripts to dedicated `completion.nix` file
- [x] Implement fish completion scripts
- [ ] Refactor flag parsing to move the bash completion stuff into its relevant file

Note: I noticed that the `nixfmt` provided in `_` by pog is `nixfmt-rfc-style` (which is also my favorite), so that's what I used to format the new file. However, it's clearly not what's used for the other files so there's something to harmonize here. Should I go ahead and format the other files, or should I switch back to the normal nixfmt?