### PR TITLE
add `default = true` for default subcommands

### DIFF
--- a/docs/specs.md
+++ b/docs/specs.md
@@ -30,9 +30,12 @@ Each command has the same shape as a top-level `pog` call — `name`, `descripti
 `flags`, `arguments`, `script` — and may itself contain a nested `commands` list, so
 subcommands can nest to any depth.
 
-- A command with `commands` (a "parent") dispatches to its subcommands. If it also has a
-  `script`, that script runs as the **default action** when no subcommand is given;
-  otherwise bare invocation prints auto-generated help listing the subcommands.
+- A command with `commands` (a "parent") dispatches to its subcommands. When no subcommand
+  is given, bare invocation runs, in order of precedence: the parent's own `script` (default
+  action), or a subcommand marked `default = true` (the parent forwards to it), or — if
+  neither is set — auto-generated help listing the subcommands. Setting both a `script` and a
+  `default = true` subcommand on the same parent is an error. The forward chains, so a default
+  subcommand that is itself a parent with its own default keeps descending.
 - Every command gets its own `--help`, flags, prompts, and tab completion.
 - `runtimeInputs` is set once at the top level and applies to all commands.
 - `beforeExit` is a per-command exit hook. Each command on the active path registers its
@@ -48,6 +51,7 @@ subcommands can nest to any depth.
   arguments = [ ];                          # optional, for leaf commands
   argumentCompletion = "files";             # optional
   script = "";                              # leaf action, or default action for a parent
+  default = false;                          # optional, mark as the parent's default subcommand
   beforeExit = "";                          # optional, this command's exit hook
   commands = [ ];                           # optional, nest subcommands here
 }

--- a/pog/default.nix
+++ b/pog/default.nix
@@ -621,13 +621,33 @@ rec {
           pathStr = concatStringsSep " " nodePath;
           childNodes = map (mkNode nodePath) children;
           childFn = c: "_pog_cmd_" + sanitizePath (nodePath ++ [ c.name ]);
+          # a child may mark itself `default = true`; bare invocation of this node
+          # then forwards to that child instead of running a script or printing help.
+          # the forward chains, so a default child that is itself a parent with its
+          # own default subcommand keeps descending.
+          defaultChildren = filter (c: c.default or false) children;
+          defaultChild =
+            if defaultChildren == [ ] then null
+            else if builtins.length defaultChildren > 1
+            then throw "pog: '${pathStr}' has more than one subcommand marked `default = true`"
+            else builtins.head defaultChildren;
+          hasDefaultChild = defaultChild != null;
           usageTail = if isParent then "<COMMAND>" else concatStringsSep " " (map toUpper nodeArgs);
-          childHelp = concatStringsSep "\n" (map (c: "${rightPad flagPadding c.name}\t${c.description or "a pog command"}") children);
+          childHelp = concatStringsSep "\n" (map (c: "${rightPad flagPadding c.name}\t${c.description or "a pog command"}${if (c.default or false) then " (default)" else ""}") children);
+          # what runs when this node is invoked bare (no subcommand). a node's own
+          # `script` and a default subcommand are both "bare action" behaviours, so
+          # allowing both would be ambiguous — reject it at eval time.
+          bareAction =
+            if hasScript && hasDefaultChild
+            then throw "pog: '${pathStr}' sets both a `script` and a `default = true` subcommand; pick one"
+            else if hasScript then nodeScript
+            else if hasDefaultChild then ''${childFn defaultChild} "$@"''
+            else helpFn;
           dispatch = ''
             case "''${1:-}" in
             ${concatStringsSep "\n" (map (c: ''${c.name}) shift; ${childFn c} "$@" ;;'') children)}
             "")
-            ${if hasScript then nodeScript else helpFn}
+            ${bareAction}
             ;;
             *)
             die "unknown command: '$1'" 3
@@ -1143,9 +1163,14 @@ rec {
       {
         name = "remote";
         description = "manage remotes";
-        # parent default action (bare `tool remote`)
-        script = ''echo "listing remotes (default action)"'';
         commands = [
+          {
+            name = "list";
+            description = "list remotes";
+            # bare `tool remote` forwards here instead of printing help
+            default = true;
+            script = ''echo "listing remotes (default subcommand)"'';
+          }
           {
             name = "add";
             description = "add a remote";


### PR DESCRIPTION
Mark a subcommand `default = true` so bare invocation of its parent forwards to it (with "$@") instead of printing help. The forward chains through nested defaults, so a default subcommand that is itself a parent with its own default keeps descending.

Precedence for a bare parent invocation: the parent's own `script`, else a `default = true` subcommand, else auto-generated help. Setting both a `script` and a default subcommand on one parent is an eval-time error. The default subcommand is marked `(default)` in `--help` output.